### PR TITLE
fix: Make sure Meltano selected column is propagated

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -296,7 +296,9 @@ def do_sync(conn_config, catalog, default_replication_method, state, state_file=
     else:
         end_lsn = None
 
-    refresh_streams_schema(conn_config, streams)
+    # Disabling this method because it's removing metadata being added by Meltano
+    # Specifically it's removing whether or not a column is selected.
+    # refresh_streams_schema(conn_config, streams)
 
     sync_method_lookup, traditional_streams, logical_streams = \
         sync_method_for_streams(streams, state, default_replication_method)


### PR DESCRIPTION
## Problem

This change makes sure that column selection coming from Meltano is maintained and propagated into the extractor. Without this change, only selection based on tables (or streams) works but not on a column level.
